### PR TITLE
[M3C-09] add type for NativeProgram

### DIFF
--- a/include/formats/internal/literals.h
+++ b/include/formats/internal/literals.h
@@ -12,7 +12,7 @@
  *
  * \warning Значение может быть любым.
  */
-typedef uint8_t _LiteralStub[4];
+typedef uint8_t _LiteralStub[3];
 
 // ## Типы по содержанию
 
@@ -20,7 +20,9 @@ typedef uint8_t _LiteralStub[4];
  * \brief Литерал, состоящий только из цифр.
  *
  * Должен соответствовать регулярному выражению <code>\d{1,3}</code>. Должен
- * быть валидной нуль-терминированной строкой в ascii кодировке.
+ * быть валидной строкой в ascii кодировке.
+ *
+ * \warning Не является нуль-терминированной строкой.
  */
 typedef _LiteralStub _DigitsLiteral;
 
@@ -28,7 +30,9 @@ typedef _LiteralStub _DigitsLiteral;
  * \brief Литерал, состоящий только из цифр и букв.
  *
  * Должен соответствовать регулярному выражению <code>[\d\w]{1,3}</code>. Должен
- * быть валидной нуль-терминированной строкой в ascii кодировке.
+ * быть валидной строкой в ascii кодировке.
+ *
+ * \warning Не является нуль-терминированной строкой.
  */
 typedef _LiteralStub _DigitsAndLettersLiteral;
 
@@ -38,7 +42,9 @@ typedef _LiteralStub _DigitsAndLettersLiteral;
  * \brief Литерал значений переменной.
  *
  * Должен соответствовать регулярному выражению <code>\d{1,3}</code>. Должен
- * быть валидной нуль-терминированной строкой в ascii кодировке.
+ * быть валидной строкой в ascii кодировке.
+ *
+ * \warning Не является нуль-терминированной строкой.
  */
 typedef _DigitsLiteral VariableValueLiteral;
 
@@ -46,7 +52,9 @@ typedef _DigitsLiteral VariableValueLiteral;
  * \brief Литерал идентификатора переменной.
  *
  * Должен соответствовать регулярному выражению <code>[\d\w]{1,3}</code>. Должен
- * быть валидной нуль-терминированной строкой в ascii кодировке.
+ * быть валидной строкой в ascii кодировке.
+ *
+ * \warning Не является нуль-терминированной строкой.
  */
 typedef _DigitsAndLettersLiteral VariableIdentificatorLiteral;
 
@@ -54,7 +62,9 @@ typedef _DigitsAndLettersLiteral VariableIdentificatorLiteral;
  * \brief Литерал идентификатора метки.
  *
  * Должен соответствовать регулярному выражению <code>[\d\w]{1,3}</code>. Должен
- * быть валидной нуль-терминированной строкой в ascii кодировке.
+ * быть валидной строкой в ascii кодировке.
+ *
+ * \warning Не является нуль-терминированной строкой.
  */
 typedef _DigitsAndLettersLiteral LabelIdentificatorLiteral;
 
@@ -62,7 +72,9 @@ typedef _DigitsAndLettersLiteral LabelIdentificatorLiteral;
  * \brief Литерал строки.
  *
  * Должен соответствовать регулярному выражению <code>[\d\w]{1,3}</code>. Должен
- * быть валидной нуль-терминированной строкой в ascii кодировке.
+ * быть валидной строкой в ascii кодировке.
+ *
+ * \warning Не является нуль-терминированной строкой.
  */
 typedef _DigitsAndLettersLiteral StringLiteral;
 

--- a/include/formats/internal/program.h
+++ b/include/formats/internal/program.h
@@ -1,0 +1,32 @@
+#ifndef MINES3C_FORMATS_INTERNAL_PROGRAM__H
+#define MINES3C_FORMATS_INTERNAL_PROGRAM__H
+
+#include <formats/internal/instructions.h>
+
+/*!
+ * \brief Количество страниц в программаторе.
+ */
+#define PAGES_PER_PROGRAM 16
+/*!
+ * \brief Количество строк на странице в программаторе.
+ */
+#define ROWS_PER_PAGE 12
+/*!
+ * \brief Количество инструкций в строке в программаторе.
+ */
+#define INSTRUCTIONS_PER_ROW 16
+
+/*!
+ * \brief Программа во внутреннем представлении.
+ *
+ * Представляет из себя фиксированного размера массив инструкций. Таким образом
+ * любая программа имеет один и тот же размер.
+ *
+ * \note Для инициализации достаточно заполнить память нулями, что установит все
+ * инструкции в #Instruction_EMPTY. Для удаления достаточно удалить стандартным
+ * аллокатором, так как не содержит ссылочных типов.
+ */
+typedef Instruction
+    NativeProgram[PAGES_PER_PROGRAM * ROWS_PER_PAGE * INSTRUCTIONS_PER_ROW];
+
+#endif /* MINES3C_FORMATS_INTERNAL_PROGRAM__H */


### PR DESCRIPTION
+ add type `NativeProgram` for native representation of program
+ decrease size of literals (from 4 to 3 bytes). Now the size of `NativeProgram` is `21504` (against `27648`). But literals are no longer null-terminated